### PR TITLE
Change format for log files and add transaction support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,31 @@ $ php /usr/share/xdmod/tools/etl/etl_overseer.php -p ingest-organizations  -p in
 ```
 
 ### Ingestion and Aggregation commands:
+Ingestion and aggregation can be run using either the `xdmod-htcss-ingestor` script or issuing a set of command using the `etl_overseer.php` script. It is suggested to use `xdmod-htcss-ingestor`.
+
+xdmod-htcss-ingestor commands
+------------------
+
+** Ingest and aggregate **
+```
+$ /bin/htcss-xdmod-ingestor -d "/path/to/log/files" --last-modified-start-date "$start_date"
+```
+
+** Ingest only **
+```
+$ /bin/htcss-xdmod-ingestor --ingest -d "/path/to/log/files" --last-modified-start-date "$start_date"
+```
+
+** Aggregate only **
+```
+$ /bin/htcss-xdmod-ingestor --aggregate --last-modified-start-date "$start_date"
+```
+
+etl_overseer.php commands
+------------------
 
 ```
-$ php /usr/share/xdmod/tools/etl/etl_overseer.php -p htcss.htcss-ingest -d 'HTCSS_LOG_DIR=/root/data/htcss/raw_aggregate/daily_logs/'
+$ php /usr/share/xdmod/tools/etl/etl_overseer.php -p htcss.htcss-ingest -d 'HTCSS_LOG_DIR=/path/to/log/files'
 $ php /usr/share/xdmod/tools/etl/etl_overseer.php -p ingest-organizations  -p ingest-resource-types -p xdmod.ingest-resources -a xdmod.staging-ingest-common.resource-specs -p xdmod.hpcdb-ingest-common -p xdmod.hpcdb-xdw-ingest-common
 $ php /usr/share/xdmod/tools/etl/etl_overseer.php -p htcss.htcss-aggregate --last-modified-start-date "$start_date"
 $ acl-config
@@ -22,7 +44,16 @@ $ xdmod-build-filter-lists -r Jobs
 
 The first command ingests logs into the database. It will ingest any file that matches the pattern of `YYYY-MM-DDTH:mm:ss_YYYY-MM-DDTHH:mm:ss.json`. The only files in this folder should be the ones you want to ingest when the command is run.
 
-For the `--last-modified-start-date flag`, the time provided should be before `htcss-ingest` pipeline was run.
+Last Modified Start Date
+------------------
+
+When aggregating data use this date as the basis of what information to include.
+Only row ingested on or after this date will be aggregated.
+The time provided should be before `htcss-ingest` pipeline was run.
+If not provided this defaults to the start of the ingest and aggregation process.
+
+The value specified for the `date` **must** be an ISO 8601 date or date and
+time (e.g. "2019-01-01" or "2019-01-01 12:00:00").
 
 ### Hierarchy
 

--- a/bin/xdmod-htcss-ingestor
+++ b/bin/xdmod-htcss-ingestor
@@ -281,11 +281,10 @@ Usage: xdmod-ingestor [-v]
         Directory to parse for log files to ingest
 
     --aggregate
-        If a *realm* (job, cloud, storage, resourcespecs) is specified aggregate that realm
-        otherwise aggregate all realms.
+        Aggregate ingested data.
 
     --ingest
-        Ingest one specific datatype (openstack, genericcloud, storage).
+        Ingest data from log files.
 
     -q, --quiet
         Output warning level and above log messages.

--- a/bin/xdmod-htcss-ingestor
+++ b/bin/xdmod-htcss-ingestor
@@ -1,0 +1,300 @@
+#!/usr/bin/env php
+<?php
+/**
+ * Ingest HTCSS aggregate data.
+ *
+ * @package xdmod-htcss
+ *
+ * @author Greg Dean <gmdean@buffalo.edu>
+ */
+
+require_once __DIR__ . '/../configuration/linker.php';
+
+use CCR\DB;
+use CCR\Log;
+use ETL\Utilities;
+use ETL\Configuration\EtlConfiguration;
+use ETL\EtlOverseer;
+use ETL\EtlOverseerOptions;
+use OpenXdmod\DataWarehouseInitializer;
+
+// Disable memory limit.
+ini_set('memory_limit', -1);
+
+try {
+    main();
+} catch (Exception $e) {
+    do {
+        fwrite(STDERR, $e->getMessage() . "\n");
+        fwrite(STDERR, $e->getTraceAsString() . "\n");
+    } while ($e = $e->getPrevious());
+    exit(1);
+}
+
+function main()
+{
+    global $argv, $logger;
+
+    $opts = array(
+        array('h', 'help'),
+        array('d:', 'htcss-log-directory:'),
+
+        // Logging levels.
+        array('v', 'verbose'),
+        array('',  'debug'),
+        array('q', 'quiet'),
+
+        array('', 'ingest'),
+        array('', 'aggregate::'),
+
+        // Date used by aggregation.
+        array('', 'last-modified-start-date:'),
+    );
+
+    $shortOptions = implode(
+        '',
+        array_map(function ($opt) { return $opt[0]; }, $opts)
+    );
+    $longOptions = array_map(function ($opt) { return $opt[1]; }, $opts);
+
+    $args = getopt($shortOptions, $longOptions);
+
+    if ($args === false) {
+        fwrite(STDERR, "Failed to parse arguments\n");
+        exit(1);
+    }
+
+    $help = $ingest = $aggregate = $noAppend = false;
+
+    $lastModifiedStartDate = $htcss_log_directory = null;
+
+    $logLevel = -1;
+
+    foreach ($args as $key => $value) {
+        if (is_array($value)) {
+            fwrite(STDERR, "Multiple values not allowed for '$key'\n");
+            exit(1);
+        }
+
+        switch ($key) {
+            case 'h':
+            case 'help':
+                $help = true;
+                break;
+            case 'q':
+            case 'quiet':
+                $logLevel = max($logLevel, Log::WARNING);
+                break;
+            case 'v':
+            case 'verbose':
+                $logLevel = max($logLevel, Log::INFO);
+                break;
+            case 'debug':
+                $logLevel = max($logLevel, Log::DEBUG);
+                break;
+            case 'ingest':
+                $ingest = true;
+                break;
+            case 'aggregate':
+                $aggregate = true;
+                break;
+            case 'last-modified-start-date':
+                $lastModifiedStartDate = $value;
+                break;
+            case 'd':
+            case 'htcss-log-directory':
+                $htcss_log_directory = $value;
+                break;
+            default:
+                fwrite(STDERR, "Unexpected option '$key'\n");
+                exit(1);
+                break;
+        }
+    }
+
+    if ($logLevel === -1) { $logLevel = Log::NOTICE; }
+
+    if ($help) {
+        displayHelpText();
+        exit;
+    }
+
+    $conf = array(
+        'file'            => false,
+        'mail'            => false,
+        'consoleLogLevel' => $logLevel,
+    );
+
+    $logger = Log::factory('htcss-xdmod-ingestor', $conf);
+
+    $cmd = implode(' ', array_map('escapeshellarg', $argv));
+    $logger->info("Command: $cmd");
+
+    if ($lastModifiedStartDate !== null && strtotime($lastModifiedStartDate) === false) {
+        $logger->crit("Invalid last modified start date '$lastModifiedStartDate'");
+        exit(1);
+    }
+
+    $db = DB::factory('datawarehouse');
+
+    if($lastModifiedStartDate === null ){
+        // Use current time from the database in case clocks are not
+        // synchronized.
+        $lastModifiedStartDate = $db->query('SELECT NOW() AS now FROM dual')[0]['now'];
+    }
+
+    // NOTE: "process_start_time" is needed for the log summary.
+    $logger->notice(array(
+        'message'            => 'htcss-xdmod-ingestor start',
+        'process_start_time' => date('Y-m-d H:i:s'),
+    ));
+
+    // If no task was explicitly specified, do ingestion and aggregation.
+    if (!$ingest && !$aggregate) {
+        $ingest = $aggregate = true;
+    }
+
+
+    if ($ingest) {
+        $logger->info('Ingesting data');
+        try {
+            $etlConfig = EtlConfiguration::factory(
+                CONFIG_DIR . '/etl/etl.json',
+                null,
+                $logger,
+                array('default_module_name' => 'xdmod')
+            );
+
+            Utilities::setEtlConfig($etlConfig);
+            // Run ingestion pipelines
+            Utilities::runEtlPipeline(
+                array(
+                  'htcss.htcss-ingest',
+                  'ingest-organizations',
+                  'ingest-resource-types',
+                  'ingest-resources'
+                ),
+                $logger,
+                array(
+                    'last-modified-start-date' => $lastModifiedStartDate,
+                    'variable-overrides' => ['HTCSS_LOG_DIR' => $htcss_log_directory]
+                )
+            );
+
+            // Set and run etl action to ingest resource specs
+            $scriptOptions = array_merge(
+                array(
+                    'default-module-name' => 'xdmod',
+                    'actions' => array('xdmod.staging-ingest-common.resource-specs')
+                )
+            );
+
+            $logger->debug(
+                sprintf(
+                    'Running ETL pipeline with script options %s',
+                    json_encode($scriptOptions)
+                )
+            );
+
+            $overseerOptions = new EtlOverseerOptions(
+                $scriptOptions,
+                $logger
+            );
+
+            $overseer = new EtlOverseer($overseerOptions, $logger);
+            $overseer->execute($etlConfig);
+
+            // Run other common ingest pipelines
+            Utilities::runEtlPipeline(
+                array(
+                  'hpcdb-ingest-common',
+                  'hpcdb-xdw-ingest-common'
+                ),
+                $logger
+            );
+        } catch (Exception $e) {
+            $logger->crit(array(
+                'message'    => 'Ingestion failed: ' . $e->getMessage(),
+                'stacktrace' => $e->getTraceAsString(),
+            ));
+            exit(1);
+        }
+        $logger->info('Done ingesting data');
+    }
+
+    if ($aggregate) {
+        $logger->info('Aggregating data');
+        try {
+            Utilities::runEtlPipeline(
+                array(
+                  'htcss.htcss-aggregate',
+                ),
+                $logger,
+                array('last-modified-start-date' => $lastModifiedStartDate)
+            );
+
+            $aclstatus = 0;
+            passthru('__XDMOD_BIN_PATH__/acl-config', $aclstatus);
+            if ($aclstatus !== 0) {
+                exit($aclstatus);
+            }
+
+            $filterListBuilder = new FilterListBuilder();
+            $filterListBuilder->setLogger($logger);
+            $filterListBuilder->buildRealmLists('Jobs');
+
+        } catch (Exception $e) {
+            $logger->crit(array(
+                'message'    => 'Aggregation failed: ' . $e->getMessage(),
+                'stacktrace' => $e->getTraceAsString(),
+            ));
+            exit(1);
+        }
+        $logger->info('Done aggregating data');
+    }
+
+    // NOTE: "process_end_time" is needed for the log summary.
+    $logger->notice(array(
+        'message'          => 'htcss-xdmod-ingestor end',
+        'process_end_time' => date('Y-m-d H:i:s'),
+    ));
+
+    exit;
+}
+
+function displayHelpText()
+{
+    echo <<<'EOF'
+
+Usage: xdmod-ingestor [-v]
+
+    -h, --help
+        Display this message and exit.
+
+    -v, --verbose
+        Output info level and above log messages.
+
+    --debug
+        Output debug level and above log messages.
+
+    -d, --htcss-log-directory
+        Directory to parse for log files to ingest
+
+    --aggregate
+        If a *realm* (job, cloud, storage, resourcespecs) is specified aggregate that realm
+        otherwise aggregate all realms.
+
+    --ingest
+        Ingest one specific datatype (openstack, genericcloud, storage).
+
+    -q, --quiet
+        Output warning level and above log messages.
+
+    --last-modified-start-date *date*
+        Specify the last modified start date (YYYY-MM-DD) to be used during
+        aggregation. Only jobs ingested on or after this date will be
+        aggregated.
+        Default: now
+
+EOF;
+}

--- a/build.json
+++ b/build.json
@@ -1,7 +1,7 @@
 {
     "name": "xdmod-htcss",
     "version": "10.5.0",
-    "release": "rc.1",
+    "release": "rc.2",
     "files": {
         "include_paths": [
         ],

--- a/classes/ETL/Ingestor/HtcssStructuredFileIngestor.php
+++ b/classes/ETL/Ingestor/HtcssStructuredFileIngestor.php
@@ -1,0 +1,127 @@
+<?php
+/* ------------------------------------------------------------------------------------------
+ * Ingestor for data loaded from a file. The defintion file contains a list
+ * of column names and data records to be loaded (either in that file or in an
+ * external file).
+ *
+ * @author Greg Dean
+ * ------------------------------------------------------------------------------------------
+ */
+
+namespace ETL\Ingestor;
+
+use Psr\Log\LoggerInterface;
+use Exception;
+use ETL\iAction;
+use ETL\aOptions;
+use ETL\Configuration\EtlConfiguration;
+use ETL\EtlOverseerOptions;
+use ETL\DataEndpoint\iStructuredFile;
+
+class HtcssStructuredFileIngestor extends StructuredFileIngestor implements iAction
+{
+    /** -----------------------------------------------------------------------------------------
+     * The custom insert values component is an object that allows us to specify a
+     * subquery to use when inserting data rather than the raw source value. If the
+     * destination column is present as a key in the object, the key's value will be used.
+     *
+     * @var array|null
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected $customInsertValuesComponents = null;
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iAction::__construct()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function __construct(aOptions $options, EtlConfiguration $etlConfig, LoggerInterface $logger = null)
+    {
+        parent::__construct($options, $etlConfig, $logger);
+    }  // __construct()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see iAction::initialize()
+     *
+     * @throws Exception if any query data was not int the correct format.
+     * ------------------------------------------------------------------------------------------
+     */
+
+    public function initialize(EtlOverseerOptions $etlOverseerOptions = null)
+    {
+        return parent::initialize($etlOverseerOptions);
+
+    }  // initialize()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see aIngestor::_execute()
+     * ------------------------------------------------------------------------------------------
+     */
+
+    // @codingStandardsIgnoreLine
+    protected function _execute()
+    {
+        return parent::_execute();
+
+    }  // _execute()
+
+    /**
+     * Build up a parameter list suitable for an SQL query. The parameters must be in the proper
+     * order as expected by the field list of the query (this mapping information is stored in
+     * $destinationFieldIdToSourceFieldMap). Note that the same source value may be used multiple
+     * times in the query.
+     *
+     * @param $sourceRecord The current record from the source endpoint (must be Traversable but
+     *   may not explicitly implement Traversable such as an array or stdClass)
+     * @param array $destinationFieldIdToSourceFieldMap A mapping between the parameter position
+     *   (index) in the SQL statement and the source fields so we cam properly build the SQL
+     *   parameter list in the correct order.
+     * @param array $sourceTemplate Templates for source field values containing pre-determined
+     *   values such as variables or macros.
+     * @param array $simpleSourceFields Scalar source fields that map to source fields.
+     * @param array $complexSourceFields Complex source fields that must be evaluated by the source
+     *   endpoint
+     *
+     * @return array A list of values to use as SQL parameters in the proper order corresponding
+     *   to the SQL query parameters.
+     */
+
+    private function generateParametersFromSourceRecord(
+        $sourceRecord,
+        array $destinationFieldIdToSourceFieldMap,
+        array $sourceTemplate,
+        array $simpleSourceFields,
+        array $complexSourceFields
+    ) {
+        return parent::generateParametersFromSourceRecord($sourceRecord, $destinationFieldIdToSourceFieldMap, $sourceTemplate, $simpleSourceFields, $complexSourceFields);
+
+    }  // generateParametersFromSourceRecord()
+
+    /** -----------------------------------------------------------------------------------------
+     * @see aIngestor::performPreExecuteTasks
+     * ------------------------------------------------------------------------------------------
+     */
+
+    protected function performPreExecuteTasks()
+    {
+        parent::performPreExecuteTasks();
+        $this->logger->debug("Starting Transaction");
+        $this->destinationHandle->beginTransaction();
+
+        return true;
+    }
+
+    /** -----------------------------------------------------------------------------------------
+     * @see aIngestor::performPostExecuteTasks
+     * ------------------------------------------------------------------------------------------
+     */
+    protected function performPostExecuteTasks($totalRecordsProcessed = NULL)
+    {
+        $this->logger->debug("Committing Transaction");
+        $this->destinationHandle->commit();
+        parent::performPostExecuteTasks($totalRecordsProcessed);
+
+        return true;
+    }
+}  // class HtcssStructuredFileIngestor

--- a/configuration/etl/etl.d/htcss.json
+++ b/configuration/etl/etl.d/htcss.json
@@ -1,7 +1,6 @@
 {
     "module": "htcss",
     "defaults": {
-
         "global": {
             "endpoints": {
                 "source": {
@@ -32,201 +31,200 @@
         }
     },
     "htcss-ingest": [{
-      "name": "HtcssRawLogsIngest",
-      "description": "Summarized data from HTCondor",
-      "class": "HtcssStructuredFileIngestor",
-      "definition_file": "htcss/staging.json",
-      "stop_on_exception": true,
-      "truncate_destination": true,
-      "endpoints": {
-          "source": {
-              "type": "directoryscanner",
-              "name": "HTCSS logs",
-              "#": "Relative paths are searched in $BASEDIR/etl_data.d",
-              "path": "${HTCSS_LOG_DIR}",
-              "file_pattern": "/(day|month|quarter|year)_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.json/",
-              "#": "Recursion depth is relative to the path",
-              "recursion_depth": 1,
-              "handler": {
-                  "type": "jsonfile",
-                  "record_separator": "\n",
-                  "record_schema_path": "htcss/record.schema.json",
-                  "#": "Explicitly specify field names as some are optional",
-                  "field_names": [
-                      "start_date",
-                      "end_date",
-                      "resource",
-                      "project",
-                      "job_wall_time_bucket",
-                      "job_wait_time_bucket",
-                      "aggregation_unit",
-                      "system_account",
-                      "processor_count",
-                      "gpu_count",
-                      "wallduration",
-                      "running_job_count",
-                      "waitduration",
-                      "submitted_job_count",
-                      "ended_job_count",
-                      "started_job_count",
-                      "resource_institution",
-                      "field_of_science",
-                      "project_pi",
-                      "project_pi_institution",
-                      "person",
-                      "person_institution"
-                  ],
-                  "filters": [{
-                    "#": "Open Stack records do not contain a record_type field so we determine it by looking at the",
-                    "#": "event type of a record.",
-                    "type": "external",
-                    "name": "jq",
-                    "path": "jq",
-                    "arguments" :"-c '.[]'"
-                  }]
-              }
-          }
-      }
-    },
-    {
-          "name": "pi-resource",
-          "description": "Ingest job PI/Resource permutations",
-          "definition_file": "htcss/pi-resource.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "pi",
-          "description": "Ingest job PIs",
-          "definition_file": "htcss/pi.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "pi-organization",
-          "description": "Ingest PI organizations",
-          "definition_file": "htcss/pi-organization.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "person-organization",
-          "description": "Ingest organization of the person who is running jobs",
-          "definition_file": "htcss/person-organization.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "resource-organization",
-          "description": "Ingest organization of the resource",
-          "definition_file": "htcss/resource-organization.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "union-user-pi--pi",
-          "description": "Ingest job PIs (combined with users)",
-          "definition_file": "htcss/union-user-pi--pi.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "union-user-pi--user",
-          "description": "Ingest job users (combined with PIs)",
-          "definition_file": "htcss/union-user-pi--user.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "union-user-pi-resource--pi",
-          "description": "Ingest job PI/Resource permutations (combined with User/Resource permutations)",
-          "definition_file": "htcss/union-user-pi-resource--pi.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "union-user-pi-resource--user",
-          "description": "Ingest job User/Resource permutations (combined with PI/Resource permutations)",
-          "definition_file": "htcss/union-user-pi-resource--user.json",
-          "endpoints":{
-              "destination": {
-                "type" : "mysql",
-                "name" : "hpcdb DB",
-                "config" : "datawarehouse",
-                "schema": "mod_shredder",
-                "create_schema_if_not_exists": true
-              }
-          }
-      },
-      {
-          "name": "set-start-and-end-date",
-          "description": "Update ingested records to include person and pi ID",
-          "namespace": "ETL\\Maintenance",
-          "options_class": "MaintenanceOptions",
-          "class": "ExecuteSql",
-          "sql_file_list": [
-              "htcss/post-ingest-update.sql"
-          ]
-      }
-    ],
-    "htcss-aggregate": [
+            "name": "HtcssRawLogsIngest",
+            "description": "Summarized data from HTCondor",
+            "class": "HtcssStructuredFileIngestor",
+            "definition_file": "htcss/staging.json",
+            "stop_on_exception": true,
+            "truncate_destination": true,
+            "endpoints": {
+                "source": {
+                    "type": "directoryscanner",
+                    "name": "HTCSS logs",
+                    "#": "Relative paths are searched in $BASEDIR/etl_data.d",
+                    "path": "${HTCSS_LOG_DIR}",
+                    "file_pattern": "/(day|month|quarter|year)_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.json/",
+                    "#": "Recursion depth is relative to the path",
+                    "recursion_depth": 1,
+                    "handler": {
+                        "type": "jsonfile",
+                        "record_separator": "\n",
+                        "record_schema_path": "htcss/record.schema.json",
+                        "#": "Explicitly specify field names as some are optional",
+                        "field_names": [
+                            "start_date",
+                            "end_date",
+                            "resource",
+                            "project",
+                            "job_wall_time_bucket",
+                            "job_wait_time_bucket",
+                            "aggregation_unit",
+                            "system_account",
+                            "processor_count",
+                            "gpu_count",
+                            "wallduration",
+                            "running_job_count",
+                            "waitduration",
+                            "submitted_job_count",
+                            "ended_job_count",
+                            "started_job_count",
+                            "resource_institution",
+                            "field_of_science",
+                            "project_pi",
+                            "project_pi_institution",
+                            "person",
+                            "person_institution"
+                        ],
+                        "filters": [{
+                            "#": "Open Stack records do not contain a record_type field so we determine it by looking at the",
+                            "#": "event type of a record.",
+                            "type": "external",
+                            "name": "jq",
+                            "path": "jq",
+                            "arguments": "-c '.[]'"
+                        }]
+                    }
+                }
+            }
+        },
         {
+            "name": "pi-resource",
+            "description": "Ingest job PI/Resource permutations",
+            "definition_file": "htcss/pi-resource.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "pi",
+            "description": "Ingest job PIs",
+            "definition_file": "htcss/pi.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "pi-organization",
+            "description": "Ingest PI organizations",
+            "definition_file": "htcss/pi-organization.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "person-organization",
+            "description": "Ingest organization of the person who is running jobs",
+            "definition_file": "htcss/person-organization.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "resource-organization",
+            "description": "Ingest organization of the resource",
+            "definition_file": "htcss/resource-organization.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "union-user-pi--pi",
+            "description": "Ingest job PIs (combined with users)",
+            "definition_file": "htcss/union-user-pi--pi.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "union-user-pi--user",
+            "description": "Ingest job users (combined with PIs)",
+            "definition_file": "htcss/union-user-pi--user.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "union-user-pi-resource--pi",
+            "description": "Ingest job PI/Resource permutations (combined with User/Resource permutations)",
+            "definition_file": "htcss/union-user-pi-resource--pi.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "union-user-pi-resource--user",
+            "description": "Ingest job User/Resource permutations (combined with PI/Resource permutations)",
+            "definition_file": "htcss/union-user-pi-resource--user.json",
+            "endpoints": {
+                "destination": {
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "mod_shredder",
+                    "create_schema_if_not_exists": true
+                }
+            }
+        },
+        {
+            "name": "set-start-and-end-date",
+            "description": "Update ingested records to include person and pi ID",
+            "namespace": "ETL\\Maintenance",
+            "options_class": "MaintenanceOptions",
+            "class": "ExecuteSql",
+            "sql_file_list": [
+                "htcss/post-ingest-update.sql"
+            ]
+        }
+    ],
+    "htcss-aggregate": [{
             "name": "ingest-day",
             "description": "Aggregate daily data",
             "definition_file": "htcss/aggregate-daily.json",
@@ -237,11 +235,11 @@
             "aggregation_units": ["day"],
             "endpoints": {
                 "destination": {
-                  "type" : "mysql",
-                  "name" : "hpcdb DB",
-                  "config" : "datawarehouse",
-                  "schema": "modw_aggregates",
-                  "create_schema_if_not_exists": true
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "modw_aggregates",
+                    "create_schema_if_not_exists": true
                 }
             }
         },
@@ -256,11 +254,11 @@
             "aggregation_units": ["month"],
             "endpoints": {
                 "destination": {
-                  "type" : "mysql",
-                  "name" : "hpcdb DB",
-                  "config" : "datawarehouse",
-                  "schema": "modw_aggregates",
-                  "create_schema_if_not_exists": true
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "modw_aggregates",
+                    "create_schema_if_not_exists": true
                 }
             }
         },
@@ -275,11 +273,11 @@
             "aggregation_units": ["quarter"],
             "endpoints": {
                 "destination": {
-                  "type" : "mysql",
-                  "name" : "hpcdb DB",
-                  "config" : "datawarehouse",
-                  "schema": "modw_aggregates",
-                  "create_schema_if_not_exists": true
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "modw_aggregates",
+                    "create_schema_if_not_exists": true
                 }
             }
         },
@@ -294,11 +292,11 @@
             "aggregation_units": ["year"],
             "endpoints": {
                 "destination": {
-                  "type" : "mysql",
-                  "name" : "hpcdb DB",
-                  "config" : "datawarehouse",
-                  "schema": "modw_aggregates",
-                  "create_schema_if_not_exists": true
+                    "type": "mysql",
+                    "name": "hpcdb DB",
+                    "config": "datawarehouse",
+                    "schema": "modw_aggregates",
+                    "create_schema_if_not_exists": true
                 }
             }
         }

--- a/configuration/etl/etl.d/htcss.json
+++ b/configuration/etl/etl.d/htcss.json
@@ -32,63 +32,63 @@
         }
     },
     "htcss-ingest": [{
-              "name": "HtcssRawLogsIngest",
-              "description": "Summarized data from HTCondor",
-              "class": "StructuredFileIngestor",
-              "definition_file": "htcss/staging.json",
-              "stop_on_exception": true,
-              "truncate_destination": true,
-              "endpoints": {
-                  "source": {
-                      "type": "directoryscanner",
-                      "name": "HTCSS logs",
-                      "#": "Relative paths are searched in $BASEDIR/etl_data.d",
-                      "path": "${HTCSS_LOG_DIR}",
-                      "file_pattern": "/[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.json/",
-                      "#": "Recursion depth is relative to the path",
-                      "recursion_depth": 1,
-                      "handler": {
-                          "type": "jsonfile",
-                          "record_separator": "\n",
-                          "record_schema_path": "htcss/record.schema.json",
-                          "#": "Explicitly specify field names as some are optional",
-                          "field_names": [
-                              "start_date",
-                              "end_date",
-                              "resource",
-                              "project",
-                              "job_wall_time_bucket",
-                              "job_wait_time_bucket",
-                              "aggregation_unit",
-                              "system_account",
-                              "processor_count",
-                              "gpu_count",
-                              "wallduration",
-                              "running_job_count",
-                              "waitduration",
-                              "submitted_job_count",
-                              "ended_job_count",
-                              "started_job_count",
-                              "resource_institution",
-                              "field_of_science",
-                              "project_pi",
-                              "project_pi_institution",
-                              "person",
-                              "person_institution"
-                          ],
-                          "filters": [{
-                            "#": "Open Stack records do not contain a record_type field so we determine it by looking at the",
-                            "#": "event type of a record.",
-                            "type": "external",
-                            "name": "jq",
-                            "path": "jq",
-                            "arguments" :"-c '.[]'"
-                          }]
-                      }
-                  }
+      "name": "HtcssRawLogsIngest",
+      "description": "Summarized data from HTCondor",
+      "class": "HtcssStructuredFileIngestor",
+      "definition_file": "htcss/staging.json",
+      "stop_on_exception": true,
+      "truncate_destination": true,
+      "endpoints": {
+          "source": {
+              "type": "directoryscanner",
+              "name": "HTCSS logs",
+              "#": "Relative paths are searched in $BASEDIR/etl_data.d",
+              "path": "${HTCSS_LOG_DIR}",
+              "file_pattern": "/(day|month|quarter|year)_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}_[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}.json/",
+              "#": "Recursion depth is relative to the path",
+              "recursion_depth": 1,
+              "handler": {
+                  "type": "jsonfile",
+                  "record_separator": "\n",
+                  "record_schema_path": "htcss/record.schema.json",
+                  "#": "Explicitly specify field names as some are optional",
+                  "field_names": [
+                      "start_date",
+                      "end_date",
+                      "resource",
+                      "project",
+                      "job_wall_time_bucket",
+                      "job_wait_time_bucket",
+                      "aggregation_unit",
+                      "system_account",
+                      "processor_count",
+                      "gpu_count",
+                      "wallduration",
+                      "running_job_count",
+                      "waitduration",
+                      "submitted_job_count",
+                      "ended_job_count",
+                      "started_job_count",
+                      "resource_institution",
+                      "field_of_science",
+                      "project_pi",
+                      "project_pi_institution",
+                      "person",
+                      "person_institution"
+                  ],
+                  "filters": [{
+                    "#": "Open Stack records do not contain a record_type field so we determine it by looking at the",
+                    "#": "event type of a record.",
+                    "type": "external",
+                    "name": "jq",
+                    "path": "jq",
+                    "arguments" :"-c '.[]'"
+                  }]
               }
-      },
-      {
+          }
+      }
+    },
+    {
           "name": "pi-resource",
           "description": "Ingest job PI/Resource permutations",
           "definition_file": "htcss/pi-resource.json",

--- a/xdmod-htcss.spec.in
+++ b/xdmod-htcss.spec.in
@@ -35,6 +35,7 @@ rm -rf $RPM_BUILD_ROOT
 
 %files
 %defattr(-,root,root,-)
+%{_bindir}/xdmod-htcss-ingestor
 %{_docdir}/%{name}-%{version}__PRERELEASE__/
 %{_sysconfdir}/xdmod/
 %{_datadir}/xdmod/


### PR DESCRIPTION
There are 3 main changes for this PR.

- Update the file format that is used to scan a directory for files.
- Add explicit transaction by creating a new Ingestor that can uses the performPreExecuteTasks and performPostExecuteTasks to start and end the transaction. In the future this will be replaced by support for transactions on Open XDMoD. This improves performance considerably.
- `xdmod-htcss-ingestor` script to use instead of using the `etl_overseer.php` script.